### PR TITLE
Update configAssistPMem.h

### DIFF
--- a/src/configAssistPMem.h
+++ b/src/configAssistPMem.h
@@ -984,7 +984,7 @@ R"=====(<input type="text" id="{key}" name="{key}" list="{key}_list" value="{val
 PROGMEM const char CONFIGASSIST_HTML_INPUT_RANGE[] = R"=====(
             <div class="card-val-ctrl">
               <div class="range-min">{min}</div>
-              <input title="{lbl}" type="range" id="{key}" name="{key}" min="{min}" max="{max}" value="{val}">
+              <input title="{lbl}" type="range" id="{key}" name="{key}" min="{min}" max="{max}" step="{step}" value="{val}">
               <div class="range-value" name="rangeVal"></div>
               <div class="range-max">{max}</div>
             </div>)=====";


### PR DESCRIPTION
Fixed a bug when step was not applied to range widget: no matter of a step value, it remained 1.

```
  - right_coordinate:
      label: when right
      range: 1600, 2000, 100
      default: 1600
```

Before:
![image](https://github.com/user-attachments/assets/5093a3ff-6107-446c-893e-ce626087509f)
Slider can be moved with a precision of 1 even if a step value was different.
After:
![image](https://github.com/user-attachments/assets/685a4498-0801-47c4-9a37-9e03c7bca33b)
Now slider is moving in nice predefined (100) steps.

