### PR TITLE
#9: Fix URL decoding in text fields

### DIFF
--- a/src/configAssistPMem.h
+++ b/src/configAssistPMem.h
@@ -772,7 +772,7 @@ document.addEventListener('DOMContentLoaded', function (event) {
   async function updateKey(key, value) {
     if(value == null ) return;
     const baseHost = document.location.origin;
-    var url = baseHost + "/cfg?" + key + "=" + value
+    var url = baseHost + "/cfg?" + encodeURIComponent(key) + "=" + encodeURIComponent(value)
 
     if (key=="_RBT"){
       let nowUTC = Math.floor(new Date().getTime() / 1000);


### PR DESCRIPTION
The content of text fields is treated as URL this makes certain special character to be saved differently.
For example a plus '+' character is being saved as a space ' '.
This PR is to solves this problem.