### PR TITLE
#11: Use right AP static IP

### DIFF
--- a/src/ConfigAssist.cpp
+++ b/src/ConfigAssist.cpp
@@ -156,7 +156,7 @@ bool ConfigAssist::setupAP(bool startMDNS){
 
   // Get ip config and setup if found
   IPAddress ip, mask, gw;
-  if(getIPFromString(get(CA_ST_STATICIP_KEY), ip, mask, gw)){
+  if(getIPFromString(get(CA_AP_STATICIP_KEY), ip, mask, gw)){
     WiFi.softAPConfig(ip,gw,mask);
   }
 


### PR DESCRIPTION
The static IP configuration is wrong when configuring our ESP as WiFi Access Point: it is taken from the static IP used when acting as WiFi station.
It should be used the key `ap_ip` (`CA_AP_STATICIP_KEY`) and not from `st_ip` (`CA_ST_STATICIP_KEY`).
This PR fixes this problem.